### PR TITLE
[ADD] Added ServerIPv4 config field.

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -30,6 +30,7 @@ func Init() {
 
 type UDMContext struct {
 	Name              string
+	ServerIPv4        string
 	NfId              string
 	GroupId           string
 	HttpIpv4Port      int

--- a/context/init.go
+++ b/context/init.go
@@ -6,6 +6,7 @@ import (
 	"free5gc/lib/path_util"
 	"free5gc/src/udm/factory"
 	"free5gc/src/udm/logger"
+	"os"
 
 	"github.com/google/uuid"
 )
@@ -24,6 +25,15 @@ func InitUDMContext(context *UDMContext) {
 	if configuration.UdmName != "" {
 		context.Name = configuration.UdmName
 	}
+	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if context.ServerIPv4 == "" {
+		logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		context.ServerIPv4 = configuration.ServerIPv4
+		if context.ServerIPv4 == "" {
+			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.ServerIPv4 = "127.0.0.1"
+		}
+	}
 	nrfclient := config.Configuration.Nrfclient
 	context.NrfUri = fmt.Sprintf("%s://%s:%d", nrfclient.Scheme, nrfclient.Ipv4Addr, nrfclient.Port)
 	sbi := configuration.Sbi
@@ -41,7 +51,8 @@ func InitUDMContext(context *UDMContext) {
 	if configuration.NrfUri != "" {
 		context.NrfUri = configuration.NrfUri
 	} else {
-		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, context.HttpIPv4Address, 29510)
+		logger.UtilLog.Warn("NRF Uri is empty! Using localhost as NRF IPv4 address.")
+		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, "127.0.0.1", 29510)
 	}
 	servingNameList := configuration.ServiceNameList
 

--- a/factory/config.go
+++ b/factory/config.go
@@ -19,6 +19,8 @@ type Info struct {
 type Configuration struct {
 	UdmName string `yaml:"udmName,omitempty"`
 
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+
 	Sbi *Sbi `yaml:"sbi,omitempty"`
 
 	ServiceNameList []string `yaml:"serviceNameList,omitempty"`

--- a/service/init.go
+++ b/service/init.go
@@ -124,12 +124,13 @@ func (udm *UDM) Start() {
 		udmPemPath = path_util.Gofree5gcPath(sbi.Tls.Pem)
 		udmKeyPath = path_util.Gofree5gcPath(sbi.Tls.Key)
 	}
-	addr := fmt.Sprintf("%s:%d", sbi.IPv4Addr, sbi.Port)
 
 	self := context.UDM_Self()
 	// util.InitUDMContext(self)
 	context.Init()
 	context.UDM_Self().InitNFService(serviceName, config.Info.Version)
+
+	addr := fmt.Sprintf("%s:%d", self.ServerIPv4, self.HttpIpv4Port)
 
 	proflie, err := consumer.BuildNFInstance(self)
 	if err != nil {


### PR DESCRIPTION
The `ServerIPv4` field will be used to specify the IP where the server will start.
The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.

These modifications were tested and no compatibility issues were found.

This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366