### PR TITLE
resynchronization process fails with determined values of SQN

### DIFF
--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	SqnMAx    int64 = 0x7FFFFFFFFFF
+	SqnMAx    int64 = 0xFFFFFFFFFFFF
 	ind       int64 = 32
 	keyStrLen int   = 32
 	opStrLen  int   = 32


### PR DESCRIPTION
Some values of SQN from UE does not synchronize in UDM and this results in authentication of failure. For example, test set 4, test set 18 and test set 19 based on 3GPP TS 35.208 version 15.0.0 Release 15.