### PR TITLE
set mandatory IE AvType

### DIFF
--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -526,6 +526,7 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 		av.XresStar = hex.EncodeToString(xresStar)
 		av.Autn = hex.EncodeToString(AUTN)
 		av.Kausf = hex.EncodeToString(kdfValForKausf)
+		av.AvType = models.AvType__5_G_HE_AKA
 	} else { // EAP-AKA'
 		response.AuthType = models.AuthType_EAP_AKA_PRIME
 
@@ -551,6 +552,7 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 		av.Autn = hex.EncodeToString(AUTN)
 		av.CkPrime = hex.EncodeToString(ckPrime)
 		av.IkPrime = hex.EncodeToString(ikPrime)
+		av.AvType = models.AvType_EAP_AKA_PRIME
 	}
 
 	response.AuthenticationVector = &av


### PR DESCRIPTION
This PR fix the missing mandatory IE avType when sending authenticationVector IE.
Please reference to 29.503 6.3.6.2.3, 6.3.6.2.8, 6.3.6.2.4, 6.3.6.2.5, and 6.3.6.3.4 for data type definition.