### PR TITLE
fix(udm): Get AMF field from UDR Response to authentication-subscript…

### DIFF
--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -334,7 +334,8 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 		return nil, problemDetails
 	}
 
-	AMF, err := hex.DecodeString("8000")
+	AMF, err := hex.DecodeString(authSubs.AuthenticationManagementField)
+
 	if err != nil {
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusForbidden,

--- a/producer/generate_auth_data.go
+++ b/producer/generate_auth_data.go
@@ -335,7 +335,6 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 	}
 
 	AMF, err := hex.DecodeString(authSubs.AuthenticationManagementField)
-
 	if err != nil {
 		problemDetails = &models.ProblemDetails{
 			Status: http.StatusForbidden,


### PR DESCRIPTION
This change allow UDM to retrieve amf field from UDR database instead to get an hard-coded value previously (8000). This allow to tune UDR mongo database element to map UE SIM amf parameters. amf field is part of authentication vector.