### PR TITLE
Write supiOrSuci to log on re-sync failure 

### DIFF
--- a/internal/sbi/producer/generate_auth_data.go
+++ b/internal/sbi/producer/generate_auth_data.go
@@ -394,7 +394,7 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 			sqnStr = fmt.Sprintf("%x", bigSQN)
 			sqnStr = strictHex(sqnStr, 12)
 		} else {
-			logger.UeauLog.Errorln("Re-Sync MAC failed ", supi)
+			logger.UeauLog.Errorln("Re-Sync MAC failed ", supiOrSuci)
 			logger.UeauLog.Errorln("MACS ", macS)
 			logger.UeauLog.Errorln("Auts[6:] ", Auts[6:])
 			logger.UeauLog.Errorln("Sqn ", SQNms)

--- a/internal/sbi/producer/generate_auth_data.go
+++ b/internal/sbi/producer/generate_auth_data.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -395,6 +396,17 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 			sqnStr = strictHex(sqnStr, 12)
 		} else {
 			logger.UeauLog.Errorln("Re-Sync MAC failed ", supiOrSuci)
+			// Check if suci
+			if suciPart := strings.Split(supiOrSuci, "-"); suciPart[0] == "suci" {
+				// Get SuciProfile index and write public key
+				keyIndex, err := strconv.Atoi(suciPart[suci.HNPublicKeyIDPlace])
+				if err != nil {
+					logger.UeauLog.Errorln("Re-Sync Failed UDM Public Key HNPublicKeyIDPlace parse Error")
+				} else {
+					logger.UeauLog.Errorln("Re-Sync Failed UDM Public Key ",
+						udm_context.UDM_Self().SuciProfiles[keyIndex-1].PublicKey)
+				}
+			}
 			logger.UeauLog.Errorln("MACS ", macS)
 			logger.UeauLog.Errorln("Auts[6:] ", Auts[6:])
 			logger.UeauLog.Errorln("Sqn ", SQNms)

--- a/internal/sbi/producer/generate_auth_data.go
+++ b/internal/sbi/producer/generate_auth_data.go
@@ -399,8 +399,8 @@ func GenerateAuthDataProcedure(authInfoRequest models.AuthenticationInfoRequest,
 			// Check if suci
 			if suciPart := strings.Split(supiOrSuci, "-"); suciPart[0] == "suci" {
 				// Get SuciProfile index and write public key
-				keyIndex, err := strconv.Atoi(suciPart[suci.HNPublicKeyIDPlace])
-				if err != nil {
+				keyIndex, err1 := strconv.Atoi(suciPart[suci.HNPublicKeyIDPlace])
+				if err1 != nil {
 					logger.UeauLog.Errorln("Re-Sync Failed UDM Public Key HNPublicKeyIDPlace parse Error")
 				} else {
 					logger.UeauLog.Errorln("Re-Sync Failed UDM Public Key ",


### PR DESCRIPTION
Hello, I am Virgil, a security researcher from the WSPR (Wolfpack Security and Privacy Research) lab at North Carolina State University.

As part of an ongoing 5G security project, we have done some error handling analysis of free5GC. One finding involves the writing of `supi` to log in the event of a re-sync error. This occurs at `internal/sbi/producer/generate_auth_data.go` Line 297. `supi` is considered a sensitive identifier, as per TS 33.501 Section 5.2.5.

This PR changes the `supi` log write to `supiOrSuci` and adds a write of the UDM public key for ease of configuration identification.

The change to writing `supiOrSuci` ensures the encrypted SUCI is written to log rather than SUPI, if it is present.

The addition of the UDM public key allows for easier `suciProfile` configuration YAML identification, in the event of multiple UDMs. The public key is in the SUCI, but this prevents an auditor from having to parse the SUCI to identify the neccessary keys for decryption.

The writing of SUCI instead of SUPI (if present) still allows for the debugging of the re-sync error (as the operator should have access to the private key), but prevents the SUPI from being written to log.

Will open submodule hash update PR in main repo if accepted. 