### PR TITLE
Send Deregistration Notify before UDM modifies the UE context

### DIFF
--- a/internal/sbi/producer/callback/callback.go
+++ b/internal/sbi/producer/callback/callback.go
@@ -3,6 +3,7 @@ package callback
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/free5gc/openapi/Nudm_SubscriberDataManagement"
 	"github.com/free5gc/openapi/Nudm_UEContextManagement"
@@ -50,13 +51,13 @@ func DataChangeNotificationProcedure(notifyItems []models.NotifyItem, supi strin
 }
 
 func SendOnDeregistrationNotification(ueId string, onDeregistrationNotificationUrl string,
-	deregistData models.DeregistrationData,
+	deregistData models.DeregistrationData, queryParams url.Values,
 ) *models.ProblemDetails {
 	configuration := Nudm_UEContextManagement.NewConfiguration()
 	clientAPI := Nudm_UEContextManagement.NewAPIClient(configuration)
 
 	httpResponse, err := clientAPI.DeregistrationNotificationCallbackApi.DeregistrationNotify(
-		context.TODO(), onDeregistrationNotificationUrl, deregistData)
+		context.TODO(), onDeregistrationNotificationUrl, deregistData, queryParams)
 	if err != nil {
 		if httpResponse == nil {
 			logger.HttpLog.Error(err.Error())

--- a/internal/sbi/producer/callback/callback.go
+++ b/internal/sbi/producer/callback/callback.go
@@ -3,7 +3,6 @@ package callback
 import (
 	"context"
 	"net/http"
-	"net/url"
 
 	"github.com/free5gc/openapi/Nudm_SubscriberDataManagement"
 	"github.com/free5gc/openapi/Nudm_UEContextManagement"
@@ -51,13 +50,13 @@ func DataChangeNotificationProcedure(notifyItems []models.NotifyItem, supi strin
 }
 
 func SendOnDeregistrationNotification(ueId string, onDeregistrationNotificationUrl string,
-	deregistData models.DeregistrationData, queryParams url.Values,
+	deregistData models.DeregistrationData,
 ) *models.ProblemDetails {
 	configuration := Nudm_UEContextManagement.NewConfiguration()
 	clientAPI := Nudm_UEContextManagement.NewAPIClient(configuration)
 
 	httpResponse, err := clientAPI.DeregistrationNotificationCallbackApi.DeregistrationNotify(
-		context.TODO(), onDeregistrationNotificationUrl, deregistData, queryParams)
+		context.TODO(), onDeregistrationNotificationUrl, deregistData)
 	if err != nil {
 		if httpResponse == nil {
 			logger.HttpLog.Error(err.Error())

--- a/internal/sbi/producer/ue_context_management.go
+++ b/internal/sbi/producer/ue_context_management.go
@@ -225,12 +225,12 @@ func RegistrationAmf3gppAccessProcedure(registerRequest models.Amf3GppAccessRegi
 			AccessType:  models.AccessType__3_GPP_ACCESS,
 		}
 		// Deregistration Notify Triggered
-		problemDetails := callback.SendOnDeregistrationNotification(ueID,
+		pd := callback.SendOnDeregistrationNotification(ueID,
 			oldAmf3GppAccessRegContext.DeregCallbackUri,
 			deregistData,
 		)
-		if problemDetails != nil {
-			return nil, nil, problemDetails
+		if pd != nil {
+			return nil, nil, pd
 		}
 	}
 

--- a/internal/sbi/producer/ue_context_management.go
+++ b/internal/sbi/producer/ue_context_management.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -256,17 +255,15 @@ func RegistrationAmf3gppAccessProcedure(registerRequest models.Amf3GppAccessRegi
 	if oldAmf3GppAccessRegContext != nil {
 		if !ue.SameAsStoredGUAMI3gpp(*oldAmf3GppAccessRegContext.Guami) {
 			deregistData := models.DeregistrationData{
-				DeregReason: models.DeregistrationReason_SUBSCRIPTION_WITHDRAWN,
+				DeregReason: models.DeregistrationReason_UE_INITIAL_REGISTRATION,
 				AccessType:  models.AccessType__3_GPP_ACCESS,
 			}
 
 			logger.UecmLog.Infof("Send DeregNotify to old AMF GUAMI=%v", oldAmf3GppAccessRegContext.Guami)
 			go func() {
-				queryParams := url.Values{"type": []string{"implicit"}}
 				pd := callback.SendOnDeregistrationNotification(ueID,
 					oldAmf3GppAccessRegContext.DeregCallbackUri,
-					deregistData,
-					queryParams) // Deregistration Notify Triggered
+					deregistData) // Deregistration Notify Triggered
 				if pd != nil {
 					logger.UecmLog.Errorf("RegistrationAmf3gppAccess: send DeregNotify fail %v", pd)
 				}
@@ -343,12 +340,11 @@ func RegisterAmfNon3gppAccessProcedure(registerRequest models.AmfNon3GppAccessRe
 	// corresponding to the same (e.g. 3GPP) access, if one exists
 	if oldAmfNon3GppAccessRegContext != nil {
 		deregistData := models.DeregistrationData{
-			DeregReason: models.DeregistrationReason_SUBSCRIPTION_WITHDRAWN,
+			DeregReason: models.DeregistrationReason_UE_INITIAL_REGISTRATION,
 			AccessType:  models.AccessType_NON_3_GPP_ACCESS,
 		}
-		queryParams := url.Values{"type": []string{"implicit"}}
 		callback.SendOnDeregistrationNotification(ueID, oldAmfNon3GppAccessRegContext.DeregCallbackUri,
-			deregistData, queryParams) // Deregistration Notify Triggered
+			deregistData) // Deregistration Notify Triggered
 
 		return nil, nil, nil
 	} else {


### PR DESCRIPTION
* If sending Deregistration Notify after UDM modifies the UE context, old AMF can't deregister for the UE.

https://github.com/free5gc/amf/pull/107