### PR TITLE
Fix: out of range error in suci to supi

### DIFF
--- a/pkg/suci/suci.go
+++ b/pkg/suci/suci.go
@@ -382,7 +382,7 @@ func ToSupi(suci string, suciProfiles []SuciProfile) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Parse HNPublicKeyID error: %+v", err)
 	}
-	if keyIndex > len(suciProfiles) {
+	if keyIndex < 1 || keyIndex > len(suciProfiles) {
 		return "", fmt.Errorf("keyIndex(%d) out of range(%d)", keyIndex, len(suciProfiles))
 	}
 


### PR DESCRIPTION
Fix [#635](https://github.com/free5gc/free5gc/issues/635).
Add a check to avoid udm panic when home network public key identifier is 0.