### PR TITLE
Improve the security of SUCI to SUPI conversion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -207,6 +207,10 @@ linters-settings:
   misspell:
     #locale: US
     ignore-words:
+  staticcheck:
+    checks:
+      - all
+      - '-SA1019' # https://github.com/golang/go/issues/71807
   wsl:
     # If true append is only allowed to be cuddled if appending value is
     # matching variables, fields or types on line above. Default is true.

--- a/internal/sbi/processor/generate_auth_data.go
+++ b/internal/sbi/processor/generate_auth_data.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -341,24 +340,7 @@ func (p *Processor) GenerateAuthDataProcedure(
 			sqnStr = fmt.Sprintf("%x", bigSQN)
 			sqnStr = p.strictHex(sqnStr, 12)
 		} else {
-			logger.UeauLog.Errorln("Re-Sync MAC failed ", supiOrSuci)
-			// Check if suci
-			suciPart := strings.Split(supiOrSuci, "-")
-			if suciPart[suci.PrefixPlace] == suci.PrefixSUCI &&
-				suciPart[suci.SupiTypePlace] == suci.SupiTypeIMSI &&
-				suciPart[suci.SchemePlace] != suci.NullScheme {
-				// Get SuciProfile index and write public key
-				keyIndex, err1 := strconv.Atoi(suciPart[suci.HNPublicKeyIDPlace])
-				if err1 != nil {
-					logger.UeauLog.Errorln("Re-Sync Failed UDM Public Key HNPublicKeyIDPlace parse Error")
-				} else if keyIndex < 1 {
-					logger.UeauLog.Errorf("Re-Sync Failed UDM Public Key HNPublicKeyIDPlace keyIndex[%d] < 1",
-						keyIndex)
-				} else {
-					logger.UeauLog.Errorln("Re-Sync Failed UDM Public Key ",
-						p.Context().SuciProfiles[keyIndex-1].PublicKey)
-				}
-			}
+			logger.UeauLog.Errorln("Re-Sync MAC failed ", supi)
 			logger.UeauLog.Errorln("MACS ", macS)
 			logger.UeauLog.Errorln("Auts[6:] ", Auts[6:])
 			logger.UeauLog.Errorln("Sqn ", SQNms)

--- a/internal/sbi/processor/generate_auth_data.go
+++ b/internal/sbi/processor/generate_auth_data.go
@@ -340,7 +340,7 @@ func (p *Processor) GenerateAuthDataProcedure(
 			sqnStr = fmt.Sprintf("%x", bigSQN)
 			sqnStr = p.strictHex(sqnStr, 12)
 		} else {
-			logger.UeauLog.Errorln("Re-Sync MAC failed ", supi)
+			logger.UeauLog.Errorf("Re-Sync MAC failed for UE with identity supiOrSuci=[%s], resolvedSupi=[%s]", supiOrSuci, supi)
 			logger.UeauLog.Errorln("MACS ", macS)
 			logger.UeauLog.Errorln("Auts[6:] ", Auts[6:])
 			logger.UeauLog.Errorln("Sqn ", SQNms)

--- a/pkg/suci/suci.go
+++ b/pkg/suci/suci.go
@@ -241,6 +241,10 @@ func profileA(input, supiType, privateKey string) (string, error) {
 	return calcSchemeResult(decryptPlainText, supiType), nil
 }
 
+var (
+	InvalidPointError = fmt.Errorf("crypto/elliptic: attempted operation on invalid point")
+)
+
 func checkOnCurve(curve elliptic.Curve, x, y *big.Int) error {
 	// (0, 0) is the point at infinity by convention. It's ok to operate on it,
 	// although IsOnCurve is documented to return false for it. See Issue 37294.
@@ -249,7 +253,7 @@ func checkOnCurve(curve elliptic.Curve, x, y *big.Int) error {
 	}
 
 	if !curve.IsOnCurve(x, y) {
-		return fmt.Errorf("crypto/elliptic: attempted operation on invalid point")
+		return InvalidPointError
 	}
 
 	return nil

--- a/pkg/suci/suci.go
+++ b/pkg/suci/suci.go
@@ -80,9 +80,9 @@ type Suci struct {
 	SchemeOutput     string // hex string
 }
 
-func ParseSuci(input string) *Suci {
+func parseSuci(input string) *Suci {
 	matches := suciRegex.FindStringSubmatch(input)
-	if matches == nil {
+	if matches == nil || len(matches) != 10 {
 		return nil
 	}
 
@@ -337,7 +337,7 @@ func profileB(input, supiType, privateKey string) (string, error) {
 }
 
 func ToSupi(suci string, suciProfiles []SuciProfile) (string, error) {
-	parsedSuci := ParseSuci(suci)
+	parsedSuci := parseSuci(suci)
 	if parsedSuci == nil {
 		if strings.HasPrefix(suci, "imsi-") || strings.HasPrefix(suci, "nai-") {
 			logger.SuciLog.Infof("Got supi\n")

--- a/pkg/suci/suci_test.go
+++ b/pkg/suci/suci_test.go
@@ -59,13 +59,15 @@ func TestToSupi(t *testing.T) {
 				"78f5d16298634682e94373888b22bdc9293d1681922e17",
 			expectedSupi: "imsi-001010123456789",
 			expectedErr:  nil,
-		}, {
+		},
+		{
 			// Uncompressed Ephemeral Public Key + Compressed Home Public Key
 			suci: "suci-0-001-01-0-2-2-049AAB8376597021E855679A9778EA0B67396E68C66DF32C0F41E9ACCA2DA9B9D1D1F44EA1C" +
 				"87AA7478B954537BDE79951E748A43294A4F4CF86EAFF1789C9C81F46A33FC2716AC7DAE96AA30A4D",
 			expectedSupi: "imsi-00101001002086",
 			expectedErr:  nil,
-		}, {
+		},
+		{
 			suci: "suci-0-208-93-0-2-3-039aab8376597021e855679a9778ea0b67396e68c66d" +
 				"f32c0f41e9acca2da9b9d146a33fc2716ac7dae96aa30a4d",
 			expectedSupi: "imsi-20893001002086",

--- a/pkg/suci/suci_test.go
+++ b/pkg/suci/suci_test.go
@@ -52,7 +52,7 @@ func TestToSupi(t *testing.T) {
 			suci: "suci-0-208-93-0-2-2-0434a66778799d52fedd9326db4b690d092e05c9ba0ace5b413da" +
 				"fc0a40aa28ee00a79f790fa4da6a2ece892423adb130dc1b30e270b7d0088bdd716b93894891d5221a74c810d6b9350cc067c76",
 			expectedSupi: "",
-			expectedErr:  InvalidPointError,
+			expectedErr:  ErrorPublicKeyUnmarshalling,
 		},
 		{
 			suci: "suci-0-001-01-0-2-2-03a7b1db2a9db9d44112b59d03d8243dc6089fd91d2ecb" +
@@ -75,7 +75,7 @@ func TestToSupi(t *testing.T) {
 			suci: "suci-0-208-93-0-2-3-0434a66778799d52fedd9326db4b690d092e05c9ba0ace5b413da" +
 				"fc0a40aa28ee00a79f790fa4da6a2ece892423adb130dc1b30e270b7d0088bdd716b93894891d5221a74c810d6b9350cc067c76",
 			expectedSupi: "",
-			expectedErr:  InvalidPointError,
+			expectedErr:  ErrorPublicKeyUnmarshalling,
 		},
 		{
 			suci: "suci-0-001-01-0-2-3-03a7b1db2a9db9d44112b59d03d8243dc6089fd91d2ecb" +

--- a/pkg/suci/suci_test.go
+++ b/pkg/suci/suci_test.go
@@ -1,7 +1,7 @@
 package suci
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -15,8 +15,15 @@ func TestToSupi(t *testing.T) {
 		{
 			ProtectionScheme: "2", // Protect Scheme: Profile B
 			PrivateKey:       "F1AB1074477EBCC7F554EA1C5FC368B1616730155E0041AC447D6301975FECDA",
+			// Uncompressed keys
 			PublicKey: "0472DA71976234CE833A6907425867B82E074D44EF907DFB4B3E21C1C2256EBCD" +
 				"15A7DED52FCBB097A4ED250E036C7B9C8C7004C4EEDC4F068CD7BF8D3F900E3B4",
+		},
+		{
+			ProtectionScheme: "2", // Protect Scheme: Profile B
+			PrivateKey:       "F1AB1074477EBCC7F554EA1C5FC368B1616730155E0041AC447D6301975FECDA",
+			// Compressed keys
+			PublicKey: "0272DA71976234CE833A6907425867B82E074D44EF907DFB4B3E21C1C2256EBCD1",
 		},
 	}
 	testCases := []struct {
@@ -45,20 +52,50 @@ func TestToSupi(t *testing.T) {
 			suci: "suci-0-208-93-0-2-2-0434a66778799d52fedd9326db4b690d092e05c9ba0ace5b413da" +
 				"fc0a40aa28ee00a79f790fa4da6a2ece892423adb130dc1b30e270b7d0088bdd716b93894891d5221a74c810d6b9350cc067c76",
 			expectedSupi: "",
-			expectedErr:  fmt.Errorf("crypto/elliptic: attempted operation on invalid point"),
+			expectedErr:  InvalidPointError,
 		},
 		{
 			suci: "suci-0-001-01-0-2-2-03a7b1db2a9db9d44112b59d03d8243dc6089fd91d2ecb" +
 				"78f5d16298634682e94373888b22bdc9293d1681922e17",
 			expectedSupi: "imsi-001010123456789",
 			expectedErr:  nil,
+		}, {
+			// Uncompressed Ephemeral Public Key + Compressed Home Public Key
+			suci: "suci-0-001-01-0-2-2-049AAB8376597021E855679A9778EA0B67396E68C66DF32C0F41E9ACCA2DA9B9D1D1F44EA1C" +
+				"87AA7478B954537BDE79951E748A43294A4F4CF86EAFF1789C9C81F46A33FC2716AC7DAE96AA30A4D",
+			expectedSupi: "imsi-00101001002086",
+			expectedErr:  nil,
+		}, {
+			suci: "suci-0-208-93-0-2-3-039aab8376597021e855679a9778ea0b67396e68c66d" +
+				"f32c0f41e9acca2da9b9d146a33fc2716ac7dae96aa30a4d",
+			expectedSupi: "imsi-20893001002086",
+			expectedErr:  nil,
+		},
+		{
+			suci: "suci-0-208-93-0-2-3-0434a66778799d52fedd9326db4b690d092e05c9ba0ace5b413da" +
+				"fc0a40aa28ee00a79f790fa4da6a2ece892423adb130dc1b30e270b7d0088bdd716b93894891d5221a74c810d6b9350cc067c76",
+			expectedSupi: "",
+			expectedErr:  InvalidPointError,
+		},
+		{
+			suci: "suci-0-001-01-0-2-3-03a7b1db2a9db9d44112b59d03d8243dc6089fd91d2ecb" +
+				"78f5d16298634682e94373888b22bdc9293d1681922e17",
+			expectedSupi: "imsi-001010123456789",
+			expectedErr:  nil,
+		},
+		{
+			// Uncompressed Ephemeral Public Key + Uncompressed Home Public Key
+			suci: "suci-0-001-01-0-2-3-049AAB8376597021E855679A9778EA0B67396E68C66DF32C0F41E9ACCA2DA9B9D1D1F44EA1C" +
+				"87AA7478B954537BDE79951E748A43294A4F4CF86EAFF1789C9C81F46A33FC2716AC7DAE96AA30A4D",
+			expectedSupi: "imsi-00101001002086",
+			expectedErr:  nil,
 		},
 	}
 	for i, tc := range testCases {
 		supi, err := ToSupi(tc.suci, suciProfiles)
 		if err != nil {
-			if err.Error() != tc.expectedErr.Error() {
-				t.Errorf("TC%d fail: err[%s], expected[%s]\n", i, err, tc.expectedErr)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("TC%d fail: err[%v], expected[%v]\n", i, err, tc.expectedErr)
 			}
 		} else if supi != tc.expectedSupi {
 			t.Errorf("TC%d fail: supi[%s], expected[%s]\n", i, supi, tc.expectedSupi)


### PR DESCRIPTION
Hi!

This PR improves:
- The security of SUCI parsing using regex
- Use built-in function to compress/uncompress Profile-B keys instead of rolling out the crypto ourselves :-)
- Use constant time equality
- Add much needed returns on errors as well
- Stop the usage of logf.Printf
- Added some units tests about compressed and uncompressed Profile B Ephemeral and Home Keys (using test data from TS 33.501 C.4.4)
- Use crypto/ecdh (introduced in Go 1.20) instead of rolling out crypto, and factor what's possible between Profile A and Profile B

This work is part of an going project I'm working on to considerably up the code quality and security of free5gc!
This work is sponsored by [Free Mobile](https://mobile.free.fr/)!

Hope you find it useful.

CC: @ianchen0119 

Thanks and cheers,
Valentin