### PR TITLE
fix: incorrectly returns 500 for non-existent ueID

### DIFF
--- a/internal/sbi/processor/subscriber_data_management.go
+++ b/internal/sbi/processor/subscriber_data_management.go
@@ -92,7 +92,10 @@ func (p *Processor) GetIdTranslationResultProcedure(c *gin.Context, gpsi string)
 				return
 			}
 		}
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusNotFound,
+			Cause:  "DATA_NOT_FOUND",
+		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return

--- a/internal/sbi/processor/subscriber_data_management.go
+++ b/internal/sbi/processor/subscriber_data_management.go
@@ -84,14 +84,10 @@ func (p *Processor) GetIdTranslationResultProcedure(c *gin.Context, gpsi string)
 	idTranslationResultResp, err := clientAPI.QueryIdentityDataBySUPIOrGPSIDocumentApi.GetIdentityData(
 		ctx, &getIdentityDataRequest)
 	if err != nil {
-		if apiErr, ok := err.(openapi.GenericOpenAPIError); ok {
-			if getIdTransError, ok2 := apiErr.Model().(Nudr_DataRepository.GetIdentityDataError); ok2 {
-				problem := getIdTransError.ProblemDetails
-				c.Set(sbi.IN_PB_DETAILS_CTX_STR, problem.Cause)
-				c.JSON(int(problem.Status), problem)
-				return
-			}
-			c.JSON(apiErr.ErrorStatus, apiErr.RawBody)
+		apiError, ok := err.(openapi.GenericOpenAPIError)
+		if ok {
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(apiError.ErrorStatus))
+			c.JSON(apiError.ErrorStatus, apiError.RawBody)
 			return
 		}
 		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())

--- a/internal/sbi/processor/subscriber_data_management.go
+++ b/internal/sbi/processor/subscriber_data_management.go
@@ -91,11 +91,10 @@ func (p *Processor) GetIdTranslationResultProcedure(c *gin.Context, gpsi string)
 				c.JSON(int(problem.Status), problem)
 				return
 			}
+			c.JSON(apiErr.ErrorStatus, apiErr.RawBody)
+			return
 		}
-		problemDetails := &models.ProblemDetails{
-			Status: http.StatusNotFound,
-			Cause:  "DATA_NOT_FOUND",
-		}
+		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return


### PR DESCRIPTION
This PR is for fixing issue [#703](https://github.com/free5gc/free5gc/issues/703).