### PR TITLE
fix(udm): harden SDM request handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.7
 	go.uber.org/mock v0.4.0
+	golang.org/x/net v0.47.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -67,7 +68,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/sbi/api_subscriberdatamanagement.go
+++ b/internal/sbi/api_subscriberdatamanagement.go
@@ -54,6 +54,7 @@ func (s *Server) HandleGetAmData(c *gin.Context) {
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
@@ -80,7 +81,11 @@ func (s *Server) getPlmnIDStruct(
 		problemDetails = &models.ProblemDetails{
 			Title:  "Invalid Parameter",
 			Status: http.StatusBadRequest,
-			Cause:  "plmn-id parameter cannot be empty",
+			Cause:  "OPTIONAL_QUERY_PARAM_INCORRECT",
+			InvalidParams: []models.InvalidParam{{
+				Param:  "query plmn-id",
+				Reason: "cannot be empty",
+			}},
 		}
 		return nil, problemDetails
 	}
@@ -94,10 +99,22 @@ func (s *Server) getPlmnIDStruct(
 		problemDetails = &models.ProblemDetails{
 			Title:  "Invalid Parameter",
 			Status: http.StatusBadRequest,
-			Cause:  "Failed to parse plmn-id JSON",
+			Cause:  "OPTIONAL_QUERY_PARAM_INCORRECT",
 			InvalidParams: []models.InvalidParam{{
-				Param:  "plmn-id",
-				Reason: err.Error(),
+				Param:  "query plmn-id",
+				Reason: "must be a valid PlmnId JSON object",
+			}},
+		}
+		return nil, problemDetails
+	}
+	if !validator.IsValidPlmnIdParts(plmnIDStruct.Mcc, plmnIDStruct.Mnc) {
+		problemDetails = &models.ProblemDetails{
+			Title:  "Invalid Parameter",
+			Status: http.StatusBadRequest,
+			Cause:  "OPTIONAL_QUERY_PARAM_INCORRECT",
+			InvalidParams: []models.InvalidParam{{
+				Param:  "query plmn-id",
+				Reason: "MCC must contain 3 digits and MNC must contain 2 or 3 digits",
 			}},
 		}
 		return nil, problemDetails
@@ -128,6 +145,7 @@ func (s *Server) HandleGetSmfSelectData(c *gin.Context) {
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
@@ -164,6 +182,7 @@ func (s *Server) HandleGetSupi(c *gin.Context) {
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
@@ -212,14 +231,15 @@ func (s *Server) HandleSubscribeToSharedData(c *gin.Context) {
 
 	err = openapi.Deserialize(&sharedDataSubsReq, requestBody, "application/json")
 	if err != nil {
-		problemDetail := "[Request Body] " + err.Error()
+		logger.SdmLog.Errorf("[Request Body] %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.SdmLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(rsp.Status)))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(rsp.Status), rsp)
 		return
 	}
@@ -249,14 +269,15 @@ func (s *Server) HandleSubscribe(c *gin.Context) {
 
 	err = openapi.Deserialize(&sdmSubscriptionReq, requestBody, "application/json")
 	if err != nil {
-		problemDetail := "[Request Body] " + err.Error()
+		logger.SdmLog.Errorf("[Request Body] %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.SdmLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(rsp.Status)))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(rsp.Status), rsp)
 		return
 	}
@@ -338,14 +359,15 @@ func (s *Server) HandleModify(c *gin.Context) {
 
 	err = openapi.Deserialize(&sdmSubsModificationReq, requestBody, "application/json")
 	if err != nil {
-		problemDetail := "[Request Body] " + err.Error()
+		logger.SdmLog.Errorf("[Request Body] %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.SdmLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(rsp.Status)))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(rsp.Status), rsp)
 		return
 	}
@@ -374,14 +396,15 @@ func (s *Server) HandleModifyForSharedData(c *gin.Context) {
 
 	err = openapi.Deserialize(&sharedDataSubscriptions, requestBody, "application/json")
 	if err != nil {
-		problemDetail := "[Request Body] " + err.Error()
+		logger.SdmLog.Errorf("[Request Body] %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.SdmLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(rsp.Status)))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(rsp.Status), rsp)
 		return
 	}
@@ -399,7 +422,18 @@ func (s *Server) HandleGetTraceData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetTraceData")
 
 	supi := c.Params.ByName("supi")
-	plmnID := c.Query("plmn-id")
+	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
+	if problemDetails != nil {
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
+		c.JSON(int(problemDetails.Status), problemDetails)
+		return
+	}
+
+	var plmnID string
+	if plmnIDStruct != nil {
+		plmnID = plmnIDStruct.Mcc + plmnIDStruct.Mnc
+	}
 
 	s.Processor().GetTraceDataProcedure(c, supi, plmnID)
 }
@@ -432,6 +466,7 @@ func (s *Server) HandleGetNssai(c *gin.Context) {
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
@@ -459,6 +494,7 @@ func (s *Server) HandleGetSmData(c *gin.Context) {
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
@@ -567,7 +603,7 @@ func (s *Server) OneLayerPathHandlerFunc(c *gin.Context) {
 	supi := c.Param("supi")
 	oneLayerPathRouter := s.getOneLayerRoutes()
 	for _, route := range oneLayerPathRouter {
-		if strings.Contains(route.Pattern, supi) && route.Method == c.Request.Method {
+		if route.Pattern == "/"+supi && route.Method == c.Request.Method {
 			route.HandlerFunc(c)
 			return
 		}
@@ -614,14 +650,33 @@ func (s *Server) TwoLayerPathHandlerFunc(c *gin.Context) {
 	}
 
 	twoLayerPathRouter := s.getTwoLayerRoutes()
+	requestPath := "/" + supi + "/" + op
 	for _, route := range twoLayerPathRouter {
-		if strings.Contains(route.Pattern, op) && route.Method == c.Request.Method {
+		if pathPatternMatches(route.Pattern, requestPath) && route.Method == c.Request.Method {
 			route.HandlerFunc(c)
 			return
 		}
 	}
 
 	c.String(http.StatusNotFound, "404 page not found")
+}
+
+func pathPatternMatches(pattern, path string) bool {
+	patternParts := strings.Split(strings.Trim(pattern, "/"), "/")
+	pathParts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(patternParts) != len(pathParts) {
+		return false
+	}
+
+	for i := range patternParts {
+		if strings.HasPrefix(patternParts[i], ":") {
+			continue
+		}
+		if patternParts[i] != pathParts[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Server) ThreeLayerPathHandlerFunc(c *gin.Context) {

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -1,0 +1,320 @@
+package sbi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"github.com/free5gc/openapi/models"
+	udm_context "github.com/free5gc/udm/internal/context"
+	"github.com/free5gc/udm/internal/sbi/consumer"
+	"github.com/free5gc/udm/internal/sbi/processor"
+	"github.com/free5gc/udm/pkg/app"
+)
+
+type traceDataTestApp struct {
+	app.App
+	udmCtx    *udm_context.UDMContext
+	consumer  *consumer.Consumer
+	processor *processor.Processor
+}
+
+func (a *traceDataTestApp) Context() *udm_context.UDMContext {
+	return a.udmCtx
+}
+
+func (a *traceDataTestApp) Consumer() *consumer.Consumer {
+	return a.consumer
+}
+
+func (a *traceDataTestApp) Processor() *processor.Processor {
+	return a.processor
+}
+
+func (a *traceDataTestApp) CancelContext() context.Context {
+	return context.Background()
+}
+
+func TestOneLayerPathHandlerDoesNotMatchSubstrings(t *testing.T) {
+	server := &Server{}
+	for _, supi := range []string{"shared", "data", "multiple"} {
+		t.Run(supi, func(t *testing.T) {
+			target := "/" + supi + "?plmn-id=not-json"
+			recorder, c := newSDMTestContext(t, http.MethodGet, target, "")
+			c.Params = gin.Params{{Key: "supi", Value: supi}}
+
+			require.NotPanics(t, func() {
+				server.OneLayerPathHandlerFunc(c)
+			})
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "OPTIONAL_QUERY_PARAM_INCORRECT")
+		})
+	}
+}
+
+func TestPathPatternMatchesAllTwoLayerRoutes(t *testing.T) {
+	s := &Server{}
+	routes := s.getTwoLayerRoutes()
+	require.NotEmpty(t, routes)
+
+	for _, route := range routes {
+		t.Run(route.Name, func(t *testing.T) {
+			patternParts := strings.Split(strings.Trim(route.Pattern, "/"), "/")
+			pathParts := append([]string(nil), patternParts...)
+			staticPartIndex := -1
+			for i, part := range pathParts {
+				if strings.HasPrefix(part, ":") {
+					pathParts[i] = "test-value"
+				} else if staticPartIndex == -1 {
+					staticPartIndex = i
+				}
+			}
+
+			path := "/" + strings.Join(pathParts, "/")
+			require.True(t, pathPatternMatches(route.Pattern, path),
+				"route pattern %q should match %q", route.Pattern, path)
+
+			require.NotEqual(t, -1, staticPartIndex,
+				"route pattern %q should contain a fixed path segment", route.Pattern)
+			pathParts[staticPartIndex] += "-other"
+			mismatchedPath := "/" + strings.Join(pathParts, "/")
+			require.False(t, pathPatternMatches(route.Pattern, mismatchedPath),
+				"route pattern %q should not match %q", route.Pattern, mismatchedPath)
+		})
+	}
+}
+
+func TestPathPatternMatchesRejectsInvalidPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		want    bool
+	}{
+		{name: "substring does not match", pattern: "/:supi/sm-data", path: "/imsi-208930000000001/data", want: false},
+		{
+			name: "wrong static prefix", pattern: "/group-data/group-identifiers",
+			path: "/other/group-identifiers", want: false,
+		},
+		{
+			name: "missing segment", pattern: "/:supi/sm-data",
+			path: "/sm-data", want: false,
+		},
+		{
+			name: "extra segment", pattern: "/:supi/sm-data",
+			path: "/imsi-208930000000001/sm-data/extra", want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, pathPatternMatches(tt.pattern, tt.path))
+		})
+	}
+}
+
+func TestTwoLayerPathHandlerMatchesPathAndMethod(t *testing.T) {
+	server := &Server{}
+	tests := []struct {
+		name       string
+		method     string
+		operation  string
+		wantStatus int
+	}{
+		{
+			name: "matching path and method", method: http.MethodGet,
+			operation: "uc-data", wantStatus: http.StatusNotImplemented,
+		},
+		{
+			name: "substring is not a match", method: http.MethodGet,
+			operation: "data", wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "wrong method is not a match", method: http.MethodPost,
+			operation: "uc-data", wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, c := newSDMTestContext(t, tt.method, "/test-supi/"+tt.operation, "")
+			c.Params = gin.Params{
+				{Key: "supi", Value: "test-supi"},
+				{Key: "subscriptionId", Value: tt.operation},
+			}
+
+			require.NotPanics(t, func() {
+				server.TwoLayerPathHandlerFunc(c)
+			})
+			require.Equal(t, tt.wantStatus, recorder.Code)
+		})
+	}
+}
+
+func TestGetPlmnIDStruct(t *testing.T) {
+	server := &Server{}
+	tests := []struct {
+		name        string
+		query       url.Values
+		want        *models.PlmnId
+		wantProblem bool
+	}{
+		{name: "omitted", query: url.Values{}},
+		{
+			name:  "valid",
+			query: url.Values{"plmn-id": {`{"mcc":"208","mnc":"93"}`}},
+			want:  &models.PlmnId{Mcc: "208", Mnc: "93"},
+		},
+		{name: "malformed JSON", query: url.Values{"plmn-id": {`20893`}}, wantProblem: true},
+		{name: "invalid MCC", query: url.Values{"plmn-id": {`{"mcc":"AAAA","mnc":"93"}`}}, wantProblem: true},
+		{name: "invalid MNC", query: url.Values{"plmn-id": {`{"mcc":"208","mnc":"9"}`}}, wantProblem: true},
+		{
+			name:        "oversized MCC",
+			query:       url.Values{"plmn-id": {`{"mcc":"` + strings.Repeat("1", 10_000) + `","mnc":"93"}`}},
+			wantProblem: true,
+		},
+		{
+			name:        "oversized MNC",
+			query:       url.Values{"plmn-id": {`{"mcc":"208","mnc":"` + strings.Repeat("1", 10_000) + `"}`}},
+			wantProblem: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, problem := server.getPlmnIDStruct(tt.query)
+			if tt.wantProblem {
+				require.NotNil(t, problem)
+				require.Equal(t, int32(http.StatusBadRequest), problem.Status)
+				require.Equal(t, "OPTIONAL_QUERY_PARAM_INCORRECT", problem.Cause)
+				require.Equal(t, "query plmn-id", problem.InvalidParams[0].Param)
+				return
+			}
+			require.Nil(t, problem)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHandleGetTraceDataForwardsServingPlmnID(t *testing.T) {
+	const supi = "imsi-222771234567890"
+
+	requestPath := make(chan string, 1)
+	udrHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath <- r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write fake UDR response: %v", err)
+		}
+	})
+	udr := httptest.NewServer(h2c.NewHandler(udrHandler, &http2.Server{}))
+	t.Cleanup(udr.Close)
+
+	udmCtx := udm_context.GetSelf()
+	previousOAuth2Required := udmCtx.OAuth2Required
+	udmCtx.OAuth2Required = false
+	t.Cleanup(func() {
+		udmCtx.OAuth2Required = previousOAuth2Required
+	})
+	ue := udmCtx.NewUdmUe(supi)
+	ue.UdrUri = udr.URL
+	t.Cleanup(func() {
+		udmCtx.UdmUePool.Delete(supi)
+	})
+
+	testApp := &traceDataTestApp{udmCtx: udmCtx}
+	var err error
+	testApp.consumer, err = consumer.NewConsumer(testApp)
+	require.NoError(t, err)
+	testApp.processor, err = processor.NewProcessor(testApp)
+	require.NoError(t, err)
+
+	server := &Server{ServerUdm: testApp}
+	plmnID := url.QueryEscape(`{"mcc":"222","mnc":"77"}`)
+	recorder, c := newSDMTestContext(t, http.MethodGet, "/trace-data?plmn-id="+plmnID, "")
+	c.Params = gin.Params{{Key: "supi", Value: supi}}
+	server.HandleGetTraceData(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t,
+		"/nudr-dr/v2/subscription-data/"+supi+"/22277/provisioned-data/trace-data",
+		<-requestPath,
+	)
+}
+
+func TestHandleGetTraceDataRejectsMalformedPlmnID(t *testing.T) {
+	recorder, c := newSDMTestContext(t, http.MethodGet, "/trace-data?plmn-id=not-json", "")
+	c.Params = gin.Params{{Key: "supi", Value: "imsi-208930000000001"}}
+
+	server := &Server{}
+	server.HandleGetTraceData(c)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Equal(t, "application/problem+json", recorder.Header().Get("Content-Type"))
+	require.Contains(t, recorder.Body.String(), "OPTIONAL_QUERY_PARAM_INCORRECT")
+}
+
+func TestDeserializationErrorsAreSanitized(t *testing.T) {
+	server := &Server{}
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		params  gin.Params
+		handler func(*gin.Context)
+	}{
+		{
+			name: "subscribe to shared data", method: http.MethodPost, path: "/shared-data-subscriptions",
+			handler: server.HandleSubscribeToSharedData,
+		},
+		{
+			name: "subscribe", method: http.MethodPost, path: "/imsi-208930000000001/sdm-subscriptions",
+			params: gin.Params{{Key: "supi", Value: "imsi-208930000000001"}}, handler: server.HandleSubscribe,
+		},
+		{
+			name: "modify", method: http.MethodPatch, path: "/imsi-208930000000001/sdm-subscriptions/1",
+			params:  gin.Params{{Key: "ueId", Value: "imsi-208930000000001"}, {Key: "subscriptionId", Value: "1"}},
+			handler: server.HandleModify,
+		},
+		{
+			name: "modify shared data", method: http.MethodPatch, path: "/shared-data-subscriptions/1",
+			params: gin.Params{{Key: "subscriptionId", Value: "1"}}, handler: server.HandleModifyForSharedData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, c := newSDMTestContext(t, tt.method, tt.path, `[1,2,3]`)
+			c.Params = tt.params
+			tt.handler(c)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			var problem models.ProblemDetails
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &problem))
+			require.Equal(t,
+				"The request body is malformed or does not match the expected schema.", problem.Detail)
+			require.Equal(t, "INVALID_MSG_FORMAT", problem.Cause)
+			require.Equal(t, "application/problem+json", recorder.Header().Get("Content-Type"))
+			require.NotContains(t, recorder.Body.String(), "models.")
+		})
+	}
+}
+
+func newSDMTestContext(t *testing.T, method, target, body string) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	req, err := http.NewRequestWithContext(context.Background(), method, target, strings.NewReader(body))
+	require.NoError(t, err)
+	c.Request = req
+	return recorder, c
+}

--- a/internal/sbi/processor/subscriber_data_management.go
+++ b/internal/sbi/processor/subscriber_data_management.go
@@ -842,7 +842,8 @@ func (p *Processor) GetTraceDataProcedure(c *gin.Context, supi string, plmnID st
 
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		logger.SdmLog.Errorf("Create UDR client for trace-data query failed: %v", err)
+		problemDetails := openapi.ProblemDetailsSystemFailure("Upstream request failed")
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -859,7 +860,8 @@ func (p *Processor) GetTraceDataProcedure(c *gin.Context, supi string, plmnID st
 			c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 			return
 		}
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		logger.SdmLog.Errorf("Trace-data query failed: %v", err)
+		problemDetails := openapi.ProblemDetailsSystemFailure("Upstream request failed")
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return


### PR DESCRIPTION
## What this PR does

- replaces substring-based SDM route dispatch with exact, segment-aware matching
- parses and validates plmn-id consistently, including trace-data requests
- forwards a valid PLMN to UDR as the MCC and MNC path value
- returns 3GPP-aligned ProblemDetails for invalid PLMN input
- keeps deserialization details in server logs and returns a generic client-facing error
- prevents internal upstream request details from being exposed by trace-data failures
- adds regression coverage for all two-layer route patterns, route dispatch, malformed payloads, and oversized MCC/MNC values

## Validation

- golangci-lint run
- go test ./...
- go test -race ./internal/sbi
- git diff --check

## Related issues

free5gc/free5gc#1129
free5gc/free5gc#1130
free5gc/free5gc#1131
free5gc/free5gc#1132