### PR TITLE
fix: validate SUPI in six nudm-sdm GET handlers

### DIFF
--- a/internal/sbi/api_subscriberdatamanagement.go
+++ b/internal/sbi/api_subscriberdatamanagement.go
@@ -141,6 +141,20 @@ func (s *Server) HandleGetSmfSelectData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetSmfSelectData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
@@ -178,6 +192,20 @@ func (s *Server) HandleGetSupi(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetSupiRequest")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
@@ -422,6 +450,20 @@ func (s *Server) HandleGetTraceData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetTraceData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
@@ -443,6 +485,20 @@ func (s *Server) HandleGetUeContextInSmfData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetUeContextInSmfData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	supportedFeatures := c.Query("supported-features")
 
 	s.Processor().GetUeContextInSmfDataProcedure(c, supi, supportedFeatures)
@@ -462,6 +518,20 @@ func (s *Server) HandleGetNssai(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetNssai")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
@@ -490,6 +560,20 @@ func (s *Server) HandleGetSmData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetSmData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/free5gc/udm/internal/sbi/consumer"
 	"github.com/free5gc/udm/internal/sbi/processor"
 	"github.com/free5gc/udm/pkg/app"
+	"github.com/free5gc/util/validator"
 )
 
 type traceDataTestApp struct {
@@ -317,4 +318,77 @@ func newSDMTestContext(t *testing.T, method, target, body string) (*httptest.Res
 	require.NoError(t, err)
 	c.Request = req
 	return recorder, c
+}
+
+// setupSdmTestRouter registers the six nudm-sdm GET handlers under test
+// (plus HandleGetAmData as the reference handler that already validates).
+// The handlers are served by a zero-value Server: invalid-supi requests are
+// rejected before any Processor call, so no Processor stub is needed.
+func setupSdmTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+	r := gin.New()
+	group := r.Group("/nudm-sdm/v2")
+	AddService(group, []Route{
+		{"GetSmfSelectData", http.MethodGet, "/:supi/smf-select-data", s.HandleGetSmfSelectData},
+		{"GetSupi", http.MethodGet, "/:supi", s.HandleGetSupi},
+		{"GetTraceData", http.MethodGet, "/:supi/trace-data", s.HandleGetTraceData},
+		{"GetUeContextInSmfData", http.MethodGet, "/:supi/ue-context-in-smf-data", s.HandleGetUeContextInSmfData},
+		{"GetNssai", http.MethodGet, "/:supi/nssai", s.HandleGetNssai},
+		{"GetSmData", http.MethodGet, "/:supi/sm-data", s.HandleGetSmData},
+		{"GetAmData", http.MethodGet, "/:supi/am-data", s.HandleGetAmData},
+	})
+	return r
+}
+
+func TestSdmGetHandlersRejectInvalidSupi(t *testing.T) {
+	router := setupSdmTestRouter()
+
+	// CVE-2026-42459 PoC: control characters in supi make UDM build an
+	// invalid internal UDR URL and leak it in a 500 response.
+	const invalidSupi = "imsi-22277%00INJECTED"
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"smf-select-data", "/nudm-sdm/v2/" + invalidSupi + "/smf-select-data"},
+		{"supi", "/nudm-sdm/v2/" + invalidSupi},
+		{"trace-data", "/nudm-sdm/v2/" + invalidSupi + "/trace-data"},
+		{"ue-context-in-smf-data", "/nudm-sdm/v2/" + invalidSupi + "/ue-context-in-smf-data"},
+		{"nssai", "/nudm-sdm/v2/" + invalidSupi + "/nssai"},
+		{"sm-data", "/nudm-sdm/v2/" + invalidSupi + "/sm-data"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 Bad Request, got %d", w.Code)
+			}
+			var pd models.ProblemDetails
+			if err := json.Unmarshal(w.Body.Bytes(), &pd); err != nil {
+				t.Fatalf("unmarshal problem details: %v", err)
+			}
+			if pd.Detail != "Supi is invalid" {
+				t.Fatalf("expected detail %q, got %q", "Supi is invalid", pd.Detail)
+			}
+		})
+	}
+}
+
+func TestSdmValidSupiPassesValidation(t *testing.T) {
+	// Well-formed SUPIs must pass validator.IsValidSupi so the new guard
+	// blocks in the six handlers never reject legitimate requests.
+	for _, supi := range []string{
+		"imsi-222770000000001",
+		"nai-username@example.com",
+	} {
+		if !validator.IsValidSupi(supi) {
+			t.Errorf("expected %q to be a valid SUPI", supi)
+		}
+	}
 }

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -47,7 +47,7 @@ func (a *traceDataTestApp) CancelContext() context.Context {
 
 func TestOneLayerPathHandlerDoesNotMatchSubstrings(t *testing.T) {
 	server := &Server{}
-	for _, supi := range []string{"shared", "data", "multiple"} {
+	for _, supi := range []string{"imsi-208930000000001", "imsi-208930000000002", "imsi-208930000000003"} {
 		t.Run(supi, func(t *testing.T) {
 			target := "/" + supi + "?plmn-id=not-json"
 			recorder, c := newSDMTestContext(t, http.MethodGet, target, "")
@@ -362,7 +362,7 @@ func TestSdmGetHandlersRejectInvalidSupi(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 


### PR DESCRIPTION
Fixes free5gc/free5gc#1122

### Summary

Six GET handlers in `internal/sbi/api_subscriberdatamanagement.go` forwarded the `supi` path parameter to UDR without calling `validator.IsValidSupi()` (unlike `HandleGetAmData` in the same file). A crafted `supi` containing control characters makes UDM build an invalid internal UDR URL, fail `net/url` parsing, and return a 500 that leaks the full internal UDR URL in the response body — CVE-2026-42459, a missed fix of CVE-2026-27642.

### Changes

Applied the same validation block used by `HandleGetAmData` to:
- `HandleGetSmfSelectData`
- `HandleGetSupi`
- `HandleGetTraceData`
- `HandleGetUeContextInSmfData`
- `HandleGetNssai`
- `HandleGetSmData`

Invalid SUPIs now return 400 `{"detail":"Supi is invalid"}` instead of reaching UDR.

### Validation

- New test `TestSdmGetHandlersRejectInvalidSupi`: all six endpoints return 400 with `Supi is invalid` for the CVE-2026-42459 PoC input (`imsi-22277%00INJECTED`). Before the fix these requests crashed in the Processor call (nil dereference on the zero-value test server) — i.e. no validation happened.
- `TestSdmValidSupiPassesValidation`: well-formed SUPIs (`imsi-`/`nai-`) still pass `validator.IsValidSupi`.
- `go test ./internal/sbi/...`: ok (sbi, consumer, processor).
- `go vet ./internal/sbi/`: clean.
- `gofmt`: clean.
