### PR TITLE
fix: bound plmn-id mcc/mnc length and charset in UDM SDM handlers

### DIFF
--- a/internal/sbi/api_plmnid_test.go
+++ b/internal/sbi/api_plmnid_test.go
@@ -1,0 +1,75 @@
+package sbi
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// GHSA-42jf-j68x-57gx: getPlmnIDStruct parses plmn-id as JSON with no
+// length limit on mcc/mnc. An oversized mcc propagates unsanitized into
+// the path of the internal outbound UDR request, causing a ~10s timeout
+// and an error response disclosing the UDR's internal hostname/port/API
+// path — the same disclosure class as CVE-2026-42459 via payload size.
+func TestGetPlmnIDStructRejectsUnboundedMccMnc(t *testing.T) {
+	s := &Server{}
+
+	cases := []struct {
+		name    string
+		plmnID  string
+		wantBad bool
+	}{
+		{
+			name:    "oversized mcc",
+			plmnID:  `{"mcc":"` + strings.Repeat("A", 5000) + `","mnc":"77"}`,
+			wantBad: true,
+		},
+		{
+			name:    "oversized mnc",
+			plmnID:  `{"mcc":"222","mnc":"` + strings.Repeat("7", 5000) + `"}`,
+			wantBad: true,
+		},
+		{
+			name:    "non-digit mcc",
+			plmnID:  `{"mcc":"22a","mnc":"77"}`,
+			wantBad: true,
+		},
+		{
+			name:    "mcc too short",
+			plmnID:  `{"mcc":"22","mnc":"77"}`,
+			wantBad: true,
+		},
+		{
+			name:    "mnc too short",
+			plmnID:  `{"mcc":"222","mnc":"7"}`,
+			wantBad: true,
+		},
+		{
+			name:   "valid mcc/mnc",
+			plmnID: `{"mcc":"222","mnc":"77"}`,
+		},
+		{
+			name:   "valid 3-digit mnc",
+			plmnID: `{"mcc":"222","mnc":"077"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values := url.Values{"plmn-id": []string{tc.plmnID}}
+			structure, problem := s.getPlmnIDStruct(values)
+
+			if tc.wantBad {
+				if problem == nil || problem.Status != http.StatusBadRequest {
+					t.Fatalf("expected 400 problem, got structure=%+v problem=%+v",
+						structure, problem)
+				}
+				return
+			}
+			if problem != nil || structure == nil {
+				t.Fatalf("expected valid parse, got problem=%+v", problem)
+			}
+		})
+	}
+}

--- a/internal/sbi/api_subscriberdatamanagement.go
+++ b/internal/sbi/api_subscriberdatamanagement.go
@@ -102,7 +102,36 @@ func (s *Server) getPlmnIDStruct(
 		}
 		return nil, problemDetails
 	}
+	// TS 23.003: MCC is 3 digits and MNC is 2-3 digits. Bound the length
+	// and charset so an oversized/crafted mcc/mnc cannot propagate
+	// unsanitized into the internal outbound UDR request URL
+	// (GHSA-42jf-j68x-57gx).
+	if !isValidMccMnc(plmnIDStruct.Mcc, plmnIDStruct.Mnc) {
+		problemDetails = &models.ProblemDetails{
+			Title:  "Invalid Parameter",
+			Status: http.StatusBadRequest,
+			Cause:  "plmn-id contains invalid mcc/mnc",
+		}
+		return nil, problemDetails
+	}
 	return plmnIDStruct, nil
+}
+
+func isValidMccMnc(mcc, mnc string) bool {
+	if len(mcc) != 3 || len(mnc) < 2 || len(mnc) > 3 {
+		return false
+	}
+	for _, c := range mcc {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	for _, c := range mnc {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // Info - Nudm_Sdm Info service operation


### PR DESCRIPTION
Fixes #1132

### Summary

`getPlmnIDStruct` parses the `plmn-id` query parameter as JSON with no limit on the `mcc`/`mnc` fields. The parsed values are concatenated unsanitized into the path of the internal outbound request the UDM makes to the UDR. An oversized `mcc` produces a malformed, extremely long outbound URL, causing a ~10s timeout against the UDR and an error response that discloses the UDR's internal hostname, port and full API path structure — the same disclosure class as CVE-2026-42459 (`GHSA-42jf-j68x-57gx`), via payload size rather than control characters.

### Changes

After the JSON unmarshal in `getPlmnIDStruct`, reject values that do not match TS 23.003 — MCC must be 3 digits, MNC 2-3 digits — with a 400 problem detail (`plmn-id contains invalid mcc/mnc`), before the values reach any outbound request.

### Validation

- New test `TestGetPlmnIDStructRejectsUnboundedMccMnc`: oversized mcc (5000 chars), oversized mnc, non-digit mcc, mcc too short, mnc too short all return a 400 problem detail; valid 2- and 3-digit MNC parse normally. **Before this fix the oversized cases passed through unvalidated** (red), with the fix they are rejected (green).
- `go test ./internal/sbi/...`: ok (sbi, consumer, processor).
- `go vet` / `gofmt`: clean.