### PR TITLE
fix(udm): sanitize SDM processor errors

### DIFF
--- a/internal/sbi/api_subscriberdatamanagement.go
+++ b/internal/sbi/api_subscriberdatamanagement.go
@@ -141,6 +141,20 @@ func (s *Server) HandleGetSmfSelectData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetSmfSelectData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
@@ -178,6 +192,20 @@ func (s *Server) HandleGetSupi(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetSupiRequest")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
@@ -422,6 +450,20 @@ func (s *Server) HandleGetTraceData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetTraceData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
@@ -443,6 +485,20 @@ func (s *Server) HandleGetUeContextInSmfData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetUeContextInSmfData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	supportedFeatures := c.Query("supported-features")
 
 	s.Processor().GetUeContextInSmfDataProcedure(c, supi, supportedFeatures)
@@ -462,6 +518,20 @@ func (s *Server) HandleGetNssai(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetNssai")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {
@@ -490,6 +560,20 @@ func (s *Server) HandleGetSmData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle GetSmData")
 
 	supi := c.Params.ByName("supi")
+	// TS 29.503 6.1.3.5.2
+	// Validate SUPI format
+	if !validator.IsValidSupi(supi) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Supi is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Supi is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return
+	}
 	// use c.Request.URL.Query() only for getPlmnIDStruct
 	plmnIDStruct, problemDetails := s.getPlmnIDStruct(c.Request.URL.Query())
 	if problemDetails != nil {

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/free5gc/udm/internal/sbi/consumer"
 	"github.com/free5gc/udm/internal/sbi/processor"
 	"github.com/free5gc/udm/pkg/app"
+	"github.com/free5gc/util/validator"
 )
 
 type traceDataTestApp struct {
@@ -317,4 +318,77 @@ func newSDMTestContext(t *testing.T, method, target, body string) (*httptest.Res
 	require.NoError(t, err)
 	c.Request = req
 	return recorder, c
+}
+
+// setupSdmTestRouter registers the six nudm-sdm GET handlers under test
+// (plus HandleGetAmData as the reference handler that already validates).
+// The handlers are served by a zero-value Server: invalid-supi requests are
+// rejected before any Processor call, so no Processor stub is needed.
+func setupSdmTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+	r := gin.New()
+	group := r.Group("/nudm-sdm/v2")
+	AddService(group, []Route{
+		{"GetSmfSelectData", http.MethodGet, "/:supi/smf-select-data", s.HandleGetSmfSelectData},
+		{"GetSupi", http.MethodGet, "/:supi", s.HandleGetSupi},
+		{"GetTraceData", http.MethodGet, "/:supi/trace-data", s.HandleGetTraceData},
+		{"GetUeContextInSmfData", http.MethodGet, "/:supi/ue-context-in-smf-data", s.HandleGetUeContextInSmfData},
+		{"GetNssai", http.MethodGet, "/:supi/nssai", s.HandleGetNssai},
+		{"GetSmData", http.MethodGet, "/:supi/sm-data", s.HandleGetSmData},
+		{"GetAmData", http.MethodGet, "/:supi/am-data", s.HandleGetAmData},
+	})
+	return r
+}
+
+func TestSdmGetHandlersRejectInvalidSupi(t *testing.T) {
+	router := setupSdmTestRouter()
+
+	// CVE-2026-42459 PoC: control characters in supi make UDM build an
+	// invalid internal UDR URL and leak it in a 500 response.
+	const invalidSupi = "imsi-22277%00INJECTED"
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"smf-select-data", "/nudm-sdm/v2/" + invalidSupi + "/smf-select-data"},
+		{"supi", "/nudm-sdm/v2/" + invalidSupi},
+		{"trace-data", "/nudm-sdm/v2/" + invalidSupi + "/trace-data"},
+		{"ue-context-in-smf-data", "/nudm-sdm/v2/" + invalidSupi + "/ue-context-in-smf-data"},
+		{"nssai", "/nudm-sdm/v2/" + invalidSupi + "/nssai"},
+		{"sm-data", "/nudm-sdm/v2/" + invalidSupi + "/sm-data"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 Bad Request, got %d", w.Code)
+			}
+			var pd models.ProblemDetails
+			if err := json.Unmarshal(w.Body.Bytes(), &pd); err != nil {
+				t.Fatalf("unmarshal problem details: %v", err)
+			}
+			if pd.Detail != "Supi is invalid" {
+				t.Fatalf("expected detail %q, got %q", "Supi is invalid", pd.Detail)
+			}
+		})
+	}
+}
+
+func TestSdmValidSupiPassesValidation(t *testing.T) {
+	// Well-formed SUPIs must pass validator.IsValidSupi so the new guard
+	// blocks in the six handlers never reject legitimate requests.
+	for _, supi := range []string{
+		"imsi-222770000000001",
+		"nai-username@example.com",
+	} {
+		if !validator.IsValidSupi(supi) {
+			t.Errorf("expected %q to be a valid SUPI", supi)
+		}
+	}
 }

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -47,7 +47,7 @@ func (a *traceDataTestApp) CancelContext() context.Context {
 
 func TestOneLayerPathHandlerDoesNotMatchSubstrings(t *testing.T) {
 	server := &Server{}
-	for _, supi := range []string{"shared", "data", "multiple"} {
+	for _, supi := range []string{"imsi-208930000000001", "imsi-208930000000002", "imsi-208930000000003"} {
 		t.Run(supi, func(t *testing.T) {
 			target := "/" + supi + "?plmn-id=not-json"
 			recorder, c := newSDMTestContext(t, http.MethodGet, target, "")
@@ -362,7 +362,7 @@ func TestSdmGetHandlersRejectInvalidSupi(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 

--- a/internal/sbi/processor/subscriber_data_management.go
+++ b/internal/sbi/processor/subscriber_data_management.go
@@ -17,6 +17,11 @@ import (
 	"github.com/free5gc/util/metrics/sbi"
 )
 
+func newSdmSystemFailureProblemDetails(err error) *models.ProblemDetails {
+	logger.SdmLog.Errorf("SDM upstream request failed: %v", err)
+	return openapi.ProblemDetailsSystemFailure("Upstream request failed")
+}
+
 func (p *Processor) GetAmDataProcedure(c *gin.Context, supi string, plmnID string, supportedFeatures string) {
 	ctx, pd, err := p.Context().GetTokenCtx(models.ServiceName_NUDR_DR, models.NrfNfManagementNfType_UDR)
 	if err != nil {
@@ -139,7 +144,7 @@ func (p *Processor) GetSupiProcedure(c *gin.Context,
 
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -177,7 +182,7 @@ func (p *Processor) GetSupiProcedure(c *gin.Context,
 				c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 				return
 			}
-			problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+			problemDetails := newSdmSystemFailureProblemDetails(err)
 			c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 			c.JSON(int(problemDetails.Status), problemDetails)
 			return
@@ -204,7 +209,7 @@ func (p *Processor) GetSupiProcedure(c *gin.Context,
 				c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 				return
 			}
-			problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+			problemDetails := newSdmSystemFailureProblemDetails(err)
 			c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 			c.JSON(int(problemDetails.Status), problemDetails)
 			return
@@ -233,7 +238,7 @@ func (p *Processor) GetSupiProcedure(c *gin.Context,
 				c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 				return
 			}
-			problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+			problemDetails := newSdmSystemFailureProblemDetails(err)
 			c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 			c.JSON(int(problemDetails.Status), problemDetails)
 			return
@@ -285,7 +290,7 @@ func (p *Processor) GetSupiProcedure(c *gin.Context,
 				c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 				return
 			}
-			problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+			problemDetails := newSdmSystemFailureProblemDetails(err)
 			c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 			c.JSON(int(problemDetails.Status), problemDetails)
 			return
@@ -316,7 +321,7 @@ func (p *Processor) GetSupiProcedure(c *gin.Context,
 				c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 				return
 			}
-			problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+			problemDetails := newSdmSystemFailureProblemDetails(err)
 			c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 			c.JSON(int(problemDetails.Status), problemDetails)
 			return
@@ -398,7 +403,7 @@ func (p *Processor) GetSmDataProcedure(
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
 		logger.ProcLog.Errorf("CreateUDMClientToUDR Error: %+v", err)
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -434,7 +439,7 @@ func (p *Processor) GetSmDataProcedure(
 			c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 			return
 		}
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -489,7 +494,7 @@ func (p *Processor) GetNssaiProcedure(c *gin.Context, supi string, plmnID string
 	var nssaiResp models.Nssai
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -504,7 +509,7 @@ func (p *Processor) GetNssaiProcedure(c *gin.Context, supi string, plmnID string
 			c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 			return
 		}
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -536,7 +541,7 @@ func (p *Processor) GetSmfSelectDataProcedure(c *gin.Context, supi string, plmnI
 
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -553,7 +558,7 @@ func (p *Processor) GetSmfSelectDataProcedure(c *gin.Context, supi string, plmnI
 			c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 			return
 		}
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -842,8 +847,7 @@ func (p *Processor) GetTraceDataProcedure(c *gin.Context, supi string, plmnID st
 
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
-		logger.SdmLog.Errorf("Create UDR client for trace-data query failed: %v", err)
-		problemDetails := openapi.ProblemDetailsSystemFailure("Upstream request failed")
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -860,8 +864,7 @@ func (p *Processor) GetTraceDataProcedure(c *gin.Context, supi string, plmnID st
 			c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 			return
 		}
-		logger.SdmLog.Errorf("Trace-data query failed: %v", err)
-		problemDetails := openapi.ProblemDetailsSystemFailure("Upstream request failed")
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -887,7 +890,7 @@ func (p *Processor) GetUeContextInSmfDataProcedure(c *gin.Context, supi string, 
 
 	clientAPI, err := p.Consumer().CreateUDMClientToUDR(supi)
 	if err != nil {
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return
@@ -912,7 +915,7 @@ func (p *Processor) GetUeContextInSmfDataProcedure(c *gin.Context, supi string, 
 			c.Data(apiError.ErrorStatus, "application/json", apiError.RawBody)
 			return
 		}
-		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		problemDetails := newSdmSystemFailureProblemDetails(err)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
 		c.JSON(int(problemDetails.Status), problemDetails)
 		return

--- a/internal/sbi/processor/subscriber_data_management_test.go
+++ b/internal/sbi/processor/subscriber_data_management_test.go
@@ -1,0 +1,19 @@
+package processor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSdmSystemFailureProblemDetailsDoesNotExposeInternalError(t *testing.T) {
+	err := errors.New(`parse "http://udr.internal:8000/nudr-dr/v2/` +
+		`subscription-data/imsi-001": invalid control character in URL`)
+
+	problemDetails := newSdmSystemFailureProblemDetails(err)
+
+	require.Equal(t, "Upstream request failed", problemDetails.Detail)
+	require.NotContains(t, problemDetails.Detail, "udr.internal")
+	require.NotContains(t, problemDetails.Detail, "imsi-001")
+}


### PR DESCRIPTION
Depends on #91

## Summary
- Sanitize non-GenericOpenAPIError responses in the six Issue #1122-related SDM processor paths.
- Keep internal UDR URLs and parser details in server logs instead of `ProblemDetails.detail`.
- Use one shared error-to-ProblemDetails helper, including GetTraceData.
- Add a regression test proving internal URL details are not exposed.

## Relationship to #91
PR #91 adds the SUPI validation in the six Nudm_SDM GET handlers. This PR is a follow-up defense-in-depth change at the processor error boundary and intentionally does not duplicate the handler validation or API tests from #91.

Related issue: https://github.com/free5gc/free5gc/issues/1122

## Validation
- go test ./...
- go vet ./...
- golangci-lint run
- git diff --check