### PR TITLE
fix(udm): validate SDM subscription IDs

### DIFF
--- a/internal/sbi/api_subscriberdatamanagement.go
+++ b/internal/sbi/api_subscriberdatamanagement.go
@@ -27,14 +27,35 @@ func (s *Server) getSubscriberDataManagementRoutes() []Route {
 	}
 }
 
-func isValidSubscriptionID(subscriptionID string) bool {
-	id, err := strconv.Atoi(subscriptionID)
-	return err == nil && id > 0 && strconv.Itoa(id) == subscriptionID
+func isValidSDMSubscriptionID(subscriptionID string) bool {
+	id, err := strconv.ParseUint(subscriptionID, 10, 64)
+	return err == nil && id > 0 && strconv.FormatUint(id, 10) == subscriptionID
 }
 
-func validateSubscriptionID(c *gin.Context) (string, bool) {
+func isValidSharedDataSubscriptionID(subscriptionID string) bool {
+	if len(subscriptionID) == 0 || len(subscriptionID) > 128 {
+		return false
+	}
+
+	for i := 0; i < len(subscriptionID); i++ {
+		ch := subscriptionID[i]
+		if (ch < 'a' || ch > 'z') &&
+			(ch < 'A' || ch > 'Z') &&
+			(ch < '0' || ch > '9') &&
+			ch != '-' && ch != '.' && ch != '_' && ch != '~' {
+			return false
+		}
+	}
+	return true
+}
+
+func validateSubscriptionID(c *gin.Context, sharedData bool) (string, bool) {
 	subscriptionID := c.Params.ByName("subscriptionId")
-	if !isValidSubscriptionID(subscriptionID) {
+	valid := isValidSDMSubscriptionID(subscriptionID)
+	if sharedData {
+		valid = isValidSharedDataSubscriptionID(subscriptionID)
+	}
+	if !valid {
 		problemDetail := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -359,7 +380,7 @@ func (s *Server) HandleUnsubscribe(c *gin.Context) {
 		c.JSON(int(problemDetail.Status), problemDetail)
 		return
 	}
-	subscriptionID, valid := validateSubscriptionID(c)
+	subscriptionID, valid := validateSubscriptionID(c, false)
 	if !valid {
 		return
 	}
@@ -371,7 +392,7 @@ func (s *Server) HandleUnsubscribe(c *gin.Context) {
 func (s *Server) HandleUnsubscribeForSharedData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle UnsubscribeForSharedData")
 
-	subscriptionID, valid := validateSubscriptionID(c)
+	subscriptionID, valid := validateSubscriptionID(c, true)
 	if !valid {
 		return
 	}
@@ -398,7 +419,7 @@ func (s *Server) HandleModify(c *gin.Context) {
 		c.JSON(int(problemDetail.Status), problemDetail)
 		return
 	}
-	subscriptionID, valid := validateSubscriptionID(c)
+	subscriptionID, valid := validateSubscriptionID(c, false)
 	if !valid {
 		return
 	}
@@ -439,7 +460,7 @@ func (s *Server) HandleModify(c *gin.Context) {
 
 // ModifyForSharedData - modify the subscription
 func (s *Server) HandleModifyForSharedData(c *gin.Context) {
-	subscriptionID, valid := validateSubscriptionID(c)
+	subscriptionID, valid := validateSubscriptionID(c, true)
 	if !valid {
 		return
 	}

--- a/internal/sbi/api_subscriberdatamanagement.go
+++ b/internal/sbi/api_subscriberdatamanagement.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -24,6 +25,28 @@ func (s *Server) getSubscriberDataManagementRoutes() []Route {
 			s.HandleIndex,
 		},
 	}
+}
+
+func isValidSubscriptionID(subscriptionID string) bool {
+	id, err := strconv.Atoi(subscriptionID)
+	return err == nil && id > 0 && strconv.Itoa(id) == subscriptionID
+}
+
+func validateSubscriptionID(c *gin.Context) (string, bool) {
+	subscriptionID := c.Params.ByName("subscriptionId")
+	if !isValidSubscriptionID(subscriptionID) {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "Subscription ID is invalid",
+			Cause:  "MANDATORY_IE_INCORRECT",
+		}
+		logger.SdmLog.Warnln("Subscription ID is invalid")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(int(problemDetail.Status), problemDetail)
+		return "", false
+	}
+	return subscriptionID, true
 }
 
 // GetAmData - retrieve a UE's Access and Mobility Subscription Data
@@ -336,7 +359,10 @@ func (s *Server) HandleUnsubscribe(c *gin.Context) {
 		c.JSON(int(problemDetail.Status), problemDetail)
 		return
 	}
-	subscriptionID := c.Params.ByName("subscriptionId")
+	subscriptionID, valid := validateSubscriptionID(c)
+	if !valid {
+		return
+	}
 
 	s.Processor().UnsubscribeProcedure(c, ueId, subscriptionID)
 }
@@ -345,7 +371,10 @@ func (s *Server) HandleUnsubscribe(c *gin.Context) {
 func (s *Server) HandleUnsubscribeForSharedData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle UnsubscribeForSharedData")
 
-	subscriptionID := c.Params.ByName("subscriptionId")
+	subscriptionID, valid := validateSubscriptionID(c)
+	if !valid {
+		return
+	}
 	s.Processor().UnsubscribeForSharedDataProcedure(c, subscriptionID)
 }
 
@@ -369,7 +398,10 @@ func (s *Server) HandleModify(c *gin.Context) {
 		c.JSON(int(problemDetail.Status), problemDetail)
 		return
 	}
-	subscriptionID := c.Params.ByName("subscriptionId")
+	subscriptionID, valid := validateSubscriptionID(c)
+	if !valid {
+		return
+	}
 
 	requestBody, err := c.GetRawData()
 	if err != nil {
@@ -407,6 +439,11 @@ func (s *Server) HandleModify(c *gin.Context) {
 
 // ModifyForSharedData - modify the subscription
 func (s *Server) HandleModifyForSharedData(c *gin.Context) {
+	subscriptionID, valid := validateSubscriptionID(c)
+	if !valid {
+		return
+	}
+
 	var sharedDataSubscriptions models.Udm_SDM_SdmSubsModification
 	requestBody, err := c.GetRawData()
 	if err != nil {
@@ -440,7 +477,6 @@ func (s *Server) HandleModifyForSharedData(c *gin.Context) {
 	logger.SdmLog.Infof("Handle ModifyForSharedData")
 
 	supi := c.Params.ByName("supi")
-	subscriptionID := c.Params.ByName("subscriptionId")
 
 	s.Processor().ModifyForSharedDataProcedure(c, &sharedDataSubscriptions, supi, subscriptionID)
 }

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -161,7 +161,7 @@ func TestTwoLayerPathHandlerMatchesPathAndMethod(t *testing.T) {
 	}
 }
 
-func TestIsValidSubscriptionID(t *testing.T) {
+func TestIsValidSDMSubscriptionID(t *testing.T) {
 	tests := []struct {
 		name string
 		id   string
@@ -181,7 +181,30 @@ func TestIsValidSubscriptionID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, isValidSubscriptionID(tt.id))
+			require.Equal(t, tt.want, isValidSDMSubscriptionID(tt.id))
+		})
+	}
+}
+
+func TestIsValidSharedDataSubscriptionID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "positive integer", id: "1", want: true},
+		{name: "uuid", id: "550e8400-e29b-41d4-a716-446655440000", want: true},
+		{name: "opaque identifier", id: "shared_subscription.v2~a", want: true},
+		{name: "empty", id: "", want: false},
+		{name: "special characters", id: "$ne", want: false},
+		{name: "json", id: `{"$ne":null}`, want: false},
+		{name: "path separator", id: "subscription/id", want: false},
+		{name: "oversized", id: strings.Repeat("9", 10_000), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isValidSharedDataSubscriptionID(tt.id))
 		})
 	}
 }

--- a/internal/sbi/api_subscriberdatamanagement_test.go
+++ b/internal/sbi/api_subscriberdatamanagement_test.go
@@ -161,6 +161,85 @@ func TestTwoLayerPathHandlerMatchesPathAndMethod(t *testing.T) {
 	}
 }
 
+func TestIsValidSubscriptionID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "positive integer", id: "1", want: true},
+		{name: "larger positive integer", id: "42", want: true},
+		{name: "empty", id: "", want: false},
+		{name: "zero", id: "0", want: false},
+		{name: "negative integer", id: "-1", want: false},
+		{name: "leading zero", id: "01", want: false},
+		{name: "explicit plus sign", id: "+1", want: false},
+		{name: "special characters", id: "$ne", want: false},
+		{name: "non-numeric", id: "subscription", want: false},
+		{name: "oversized", id: strings.Repeat("9", 10_000), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isValidSubscriptionID(tt.id))
+		})
+	}
+}
+
+func TestHandlersRejectInvalidSubscriptionIDs(t *testing.T) {
+	validSupi := "imsi-208930000000001"
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		body    string
+		params  gin.Params
+		handler func(*gin.Context)
+	}{
+		{
+			name:    "unsubscribe",
+			method:  http.MethodDelete,
+			path:    "/" + validSupi + "/sdm-subscriptions/$ne",
+			params:  gin.Params{{Key: "ueId", Value: validSupi}, {Key: "subscriptionId", Value: "$ne"}},
+			handler: (&Server{}).HandleUnsubscribe,
+		},
+		{
+			name:    "unsubscribe shared data",
+			method:  http.MethodDelete,
+			path:    "/shared-data-subscriptions/$ne",
+			params:  gin.Params{{Key: "subscriptionId", Value: "$ne"}},
+			handler: (&Server{}).HandleUnsubscribeForSharedData,
+		},
+		{
+			name:    "modify",
+			method:  http.MethodPatch,
+			path:    "/" + validSupi + "/sdm-subscriptions/$ne",
+			body:    `{}`,
+			params:  gin.Params{{Key: "ueId", Value: validSupi}, {Key: "subscriptionId", Value: "$ne"}},
+			handler: (&Server{}).HandleModify,
+		},
+		{
+			name:    "modify shared data",
+			method:  http.MethodPatch,
+			path:    "/shared-data-subscriptions/$ne",
+			body:    `[1,2,3]`,
+			params:  gin.Params{{Key: "subscriptionId", Value: "$ne"}},
+			handler: (&Server{}).HandleModifyForSharedData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, c := newSDMTestContext(t, tt.method, tt.path, tt.body)
+			c.Params = tt.params
+
+			require.NotPanics(t, func() { tt.handler(c) })
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+			require.Contains(t, recorder.Body.String(), "Subscription ID is invalid")
+		})
+	}
+}
+
 func TestGetPlmnIDStruct(t *testing.T) {
 	server := &Server{}
 	tests := []struct {


### PR DESCRIPTION
## What this changes

- validate SDM subscription IDs before they reach the processor
- validate UE subscription IDs against the positive decimal format generated by UDR
- validate shared-data subscription IDs as bounded URI-safe opaque path segments
- reject malformed values with a generic 400 response
- add regression coverage for malformed IDs, including oversized input and `$ne`

The free5GC UDR currently generates UE SDM subscription IDs as positive decimal integers, while shared-data subscription IDs are treated as opaque values returned by the upstream service. Validating each path according to its source keeps crafted values from reaching downstream processing and avoids exposing internal errors.

Related issue: free5gc/free5gc#1133 (GHSA-f72w-jgfw-hhm9)

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
